### PR TITLE
Use touch instead of shell truncation in service timefiles

### DIFF
--- a/sv/snooze-daily/run
+++ b/sv/snooze-daily/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 mkdir -p /var/cache/snooze
 exec snooze -s 1d -t /var/cache/snooze/daily -- sh -c \
-	"test -d /etc/cron.daily && run-parts --lsbsysinit /etc/cron.daily; : > /var/cache/snooze/daily"
+	"test -d /etc/cron.daily && run-parts --lsbsysinit /etc/cron.daily; touch /var/cache/snooze/daily"

--- a/sv/snooze-hourly/run
+++ b/sv/snooze-hourly/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 mkdir -p /var/cache/snooze
 exec snooze -H \* -s 1h -t /var/cache/snooze/hourly -- sh -c \
-	"test -d /etc/cron.hourly && run-parts --lsbsysinit /etc/cron.hourly; : > /var/cache/snooze/hourly"
+	"test -d /etc/cron.hourly && run-parts --lsbsysinit /etc/cron.hourly; touch /var/cache/snooze/hourly"

--- a/sv/snooze-monthly/run
+++ b/sv/snooze-monthly/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 mkdir -p /var/cache/snooze
 exec snooze -d 1 -s 28d -t /var/cache/snooze/monthly -- sh -c \
-	"test -d /etc/cron.monthly && run-parts --lsbsysinit /etc/cron.monthly; : > /var/cache/snooze/monthly"
+	"test -d /etc/cron.monthly && run-parts --lsbsysinit /etc/cron.monthly; touch /var/cache/snooze/monthly"

--- a/sv/snooze-weekly/run
+++ b/sv/snooze-weekly/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 mkdir -p /var/cache/snooze
 exec snooze -w 0 -s 7d -t /var/cache/snooze/weekly -- sh -c \
-	"test -d /etc/cron.weekly && run-parts --lsbsysinit /etc/cron.weekly; : > /var/cache/snooze/weekly"
+	"test -d /etc/cron.weekly && run-parts --lsbsysinit /etc/cron.weekly; touch /var/cache/snooze/weekly"


### PR DESCRIPTION
When `/var/cache/snooze` is on an NFSv4 volume, there seems to be some kind of optimization that prevents mtimes from being updated when truncating already empty timefiles using shell redirection:
```
# mount | grep /
192.168.1.90:/rpi/cargo on / type nfs4 (rw,relatime,vers=4.2,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=10,sec=sys,clientaddr=192.168.1.8,local_lock=none,addr=192.168.1.90)

# ls -l weekly
-rw-r--r-- 1 root root 0 Jan 22 09:51 weekly

# date
Fri Jan 22 10:07:40 AM EST 2021

# : > weekly && ls -l weekly
-rw-r--r-- 1 root root 0 Jan 22 09:51 weekly

# touch weekly && ls -l weekly
-rw-r--r-- 1 root root 0 Jan 22 10:07 weekly
```
The result is that, once these timefiles are created and enough time has passed, the snooze jobs will continue to run every time they restart. `touch` doesn't seem to suffer from this problem.