### PR TITLE
Fix "snooze -n" output on 32-bit platforms with 64-bit time

### DIFF
--- a/snooze.c
+++ b/snooze.c
@@ -329,13 +329,13 @@ main(int argc, char *argv[])
 			char weekstr[4];
 			struct tm *tm = localtime(&t);
 			strftime(weekstr, sizeof weekstr, "%a", tm);
-			printf("%s %s %2ldd%3ldh%3ldm%3lds ",
+			printf("%s %s %2lldd%3lldh%3lldm%3llds ",
 			    isotime(tm),
 			    weekstr,
-			    ((t - now) / (60*60*24)),
-			    ((t - now) / (60*60)) % 24,
-			    ((t - now) / 60) % 60,
-			    (t - now) % 60);
+			    (long long)((t - now) / (60*60*24)),
+			    (long long)((t - now) / (60*60)) % 24,
+			    (long long)((t - now) / 60) % 60,
+			    (long long)(t - now) % 60);
 			if(jitter) {
 				printf("(plus up to %ds for jitter)\n", jitter);
 			} else {


### PR DESCRIPTION
With a recent arm-buildroot-linux-musleabi toolchain, gcc emits warnings such as this:

```
snooze.c: In function 'main':
snooze.c:332:42: warning: format '%ld' expects argument of type 'long int', but argument 4 has type 'time_t' {aka 'long long int'} [-Wformat=]
  332 |                         printf("%s %s %2ldd%3ldh%3ldm%3lds ",
      |                                       ~~~^
      |                                          |
      |                                          long int
      |                                       %2lld
......
  335 |                             ((t - now) / (60*60*24)),
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~
      |                                        |
      |                                        time_t {aka long long int}
```

Consequently, snooze's output is wrong, too:

```
$ arm/snooze -n
2024-05-30T00:00:00+0200 Thu  0d  0h  0m  5s
2024-05-31T00:00:00+0200 Fri  0d  1h  0m  5s
2024-06-01T00:00:00+0200 Sat  0d  2h  0m  5s
2024-06-02T00:00:00+0200 Sun  0d  3h  0m  5s
2024-06-03T00:00:00+0200 Mon  0d  4h  0m  5s
```

versus the correct output from an x86-64 binary:

```
$ x86-64/snooze -n
2024-05-30T00:00:00+0200 Thu  0d  5h 55m 56s
2024-05-31T00:00:00+0200 Fri  1d  5h 55m 56s
2024-06-01T00:00:00+0200 Sat  2d  5h 55m 56s
2024-06-02T00:00:00+0200 Sun  3d  5h 55m 56s
2024-06-03T00:00:00+0200 Mon  4d  5h 55m 56s
```

Since time_t doesn't have a defined width that could be specified in format strings, this patch solves the dilemma by casting all values to long long, and using %lld.